### PR TITLE
Allow the user handling portion of JsonProvider to be overridden in a subclass

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,11 +136,11 @@ class CustomProvider extends Provider {
         "secondary": ...,
         ...
       }
-  
+
   The method mey return a promise resolving with the
   expected return value.
 
-  @param use {mixed}
+  @param user {mixed}
   @return {Object<string,number>}
   */
   getRoles(user) {

--- a/index.js
+++ b/index.js
@@ -7,3 +7,8 @@ module.exports.AttributesManager = require('./lib/attributes-manager');
 module.exports.providers = {
   JsonProvider: require('./lib/providers/json')
 };
+
+// utilities
+module.exports.util = {
+  collect: require('./lib/util/collect')
+};

--- a/lib/provider.js
+++ b/lib/provider.js
@@ -33,11 +33,11 @@ module.exports = class Provider {
         "secondary": ...,
         ...
       }
-  
+
   The method mey return a promise resolving with the
   expected return value.
 
-  @param use {mixed}
+  @param user {mixed}
   @return {Object<string,number>}
   */
   getRoles(user) {

--- a/lib/providers/json.js
+++ b/lib/providers/json.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const Provider = require('../provider');
-
+const collect = require('../util/collect');
 
 /**
 Basic JSON permissions provider
@@ -25,34 +25,15 @@ module.exports = class JsonProvider extends Provider {
   The method mey return a promise resolving with the
   expected return value.
 
-  @param use {mixed}
+  @param user {mixed}
   @return {Object<string,number>}
   */
   getRoles(user) {
     const rules = this._rules || {};
-    const cache = {};
-
-    return (function collect(roles, userRoles, depth) {
-      for (let i = 0, iLen = roles.length; i < iLen; ++i) {
-        cache[roles[i]] = cache[roles[i]] || depth;
-      }
-
-      for (let i = 0, iLen = roles.length; i < iLen; ++i) {
-        if (cache[roles[i]] >= depth) {
-          let role = rules['roles'] && rules['roles'][roles[i]];
-
-          if (role) {
-            if (Array.isArray(role['inherited'])) {
-              userRoles[roles[i]] = collect(role['inherited'], {}, depth + 1);  
-            } else {
-              userRoles[roles[i]] = null;
-            }
-          }
-        }
-      }
-
-      return userRoles;
-    })(rules['users'] && rules['users'][user] || [], {}, 1);
+    const roles = rules['users'] && rules['users'][user] && rules['users'][user] || [];
+    return collect(roles, function(role) {
+      return rules['roles'] && rules['roles'][role] && rules['roles'][role]['inherited'];
+    });
   }
 
   /**

--- a/lib/util/collect.js
+++ b/lib/util/collect.js
@@ -1,0 +1,48 @@
+'use strict';
+
+var co = require('co');
+
+/**
+Utility function for providers which accepts an array of roles
+and a function that maps a role to an array of roles it inherits
+and outputs a role tree that can be returned from getRoles.
+
+Ex: {
+      "role1": {
+        "role1.1": null,
+        "role1.2": { ... },
+        ...
+      },
+      "secondary": ...,
+      ...
+    }
+
+@param roles {mixed}
+@param getInheritedRoles {function}
+@return {Object<string,number>}
+*/
+module.exports = function(roles, getInheritedRoles) {
+  const cache = {};
+
+  const collect = co.wrap(function *(roles, userRoles, depth) {
+    for (let i = 0, iLen = roles.length; i < iLen; ++i) {
+      cache[roles[i]] = cache[roles[i]] || depth;
+    }
+
+    for (let i = 0, iLen = roles.length; i < iLen; ++i) {
+      if (cache[roles[i]] >= depth) {
+        let inheritedRoles = yield Promise.resolve(getInheritedRoles(roles[i]));
+
+        if (Array.isArray(inheritedRoles)) {
+          userRoles[roles[i]] = yield collect(inheritedRoles, {}, depth + 1);
+        } else {
+          userRoles[roles[i]] = null;
+        }
+      }
+    }
+
+    return userRoles;
+  });
+
+  return collect(roles, {}, 1);
+};

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "url": "https://github.com/yanickrochon/rbac-a/issues"
   },
   "dependencies": {
+    "co": "^4.6.0",
     "error-factory": "^0.1.6",
     "promise-events": "0.1.2"
   },

--- a/test/providers/json.test.js
+++ b/test/providers/json.test.js
@@ -47,7 +47,6 @@ describe('Test JSON provider', function () {
     provider.should.be.instanceOf(Provider);
   });
 
-
   describe('Testing getRoles', function () {
 
     it('should return simple role', function () {
@@ -62,7 +61,7 @@ describe('Test JSON provider', function () {
 
       let provider = new JsonProvider(RULES);
 
-      provider.getRoles('joe').should.deepEqual(expected);
+      provider.getRoles('joe').should.eventually.deepEqual(expected);
     });
 
     it('should ignore missing user', function () {
@@ -70,7 +69,7 @@ describe('Test JSON provider', function () {
 
       let provider = new JsonProvider(RULES);
 
-      provider.getRoles('missing').should.deepEqual(expected);
+      provider.getRoles('missing').should.eventually.deepEqual(expected);
     });
 
     it('should ignore missing roles', function () {
@@ -78,7 +77,7 @@ describe('Test JSON provider', function () {
 
       let provider = new JsonProvider(RULES);
 
-      provider.getRoles('jim').should.deepEqual(expected);
+      provider.getRoles('jim').should.eventually.deepEqual(expected);
     });
 
     it('should skip if no rule', function () {
@@ -87,7 +86,7 @@ describe('Test JSON provider', function () {
       let provider = new JsonProvider();
       provider._rules = null;
 
-      provider.getRoles('joe').should.deepEqual(expected);
+      provider.getRoles('joe').should.eventually.deepEqual(expected);
     });
 
   });


### PR DESCRIPTION
This should permit roles to be defined in JSON config but user roles to come from a database.
